### PR TITLE
Fix auto height flicker

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -257,7 +257,7 @@ export default {
         const [entry] = entries
 
         requestAnimationFrame(() => {
-          this.modal.renderedHeight = entry.contentRect.height
+          this.modal.renderedHeight = Math.ceil(entry.contentRect.height)
         })
       }
     })


### PR DESCRIPTION
This PR fixes an issue where the modal would start to flicker because of subpixel precision in this comparison, causing the `height` to alternate between `auto` and some calculated pixel value really fast.

https://github.com/FeBe95/vue-js-modal/blob/4dd82c3b0c35218a4809cf9bd9f1d93e8a059301/src/components/Modal.vue#L392-L394

Before & after:

https://github.com/user-attachments/assets/b051eab4-75ee-4022-ab62-34fdadb8c7f1

config:

```js
{
  width: '960px',
  height: 'auto',
  minWidth: 300,
  adaptive: true,
  focusTrap: true,
  reset: true,
  clickToClose: false
}
```

