### PR TITLE
Add vue devtools compatibility

### DIFF
--- a/src/PluginCore.js
+++ b/src/PluginCore.js
@@ -86,6 +86,10 @@ const PluginCore = (app, options = {}) => {
 
     render(vNode, element)
 
+    if (!options.devtools) {
+      return
+    }
+
     let rootInstance = app._instance
 
     // AsyncComponentWrapper instances will be available here.

--- a/src/PluginCore.js
+++ b/src/PluginCore.js
@@ -42,6 +42,37 @@ const PluginCore = (app, options = {}) => {
     )
   }
 
+  const patchVueRenderer = (instance, vNode) => {
+    if (!instance || instance.rendererAlreadyPatched) {
+      return
+    }
+
+    const originalRender = instance.render
+
+    instance.render = function (...args) {
+      const result = originalRender?.apply(this, args)
+
+      if (!result?.children || !result?.children.length) {
+        result.children = []
+      }
+
+      result?.children.push(vNode)
+      return result
+    }
+
+    instance.rendererAlreadyPatched = true
+  }
+
+  const walkTreeAndPush = (treeNode, vNode) => {
+    if (!treeNode) return
+
+    if (treeNode.component) {
+      walkTreeAndPush(treeNode.component.subTree, vNode)
+    } else if (treeNode.children?.length) {
+      treeNode.children.push(vNode)
+    }
+  }
+
   /**
    * Creates a container for modals in the root Vue component.
    */
@@ -54,6 +85,31 @@ const PluginCore = (app, options = {}) => {
     vNode.appContext = app._context
 
     render(vNode, element)
+
+    let rootInstance = app._instance
+
+    // AsyncComponentWrapper instances will be available here.
+    // We can push the vNode to the tree directly.
+    if (rootInstance !== null) {
+      walkTreeAndPush(rootInstance.subTree, vNode)
+      return
+    }
+
+    // Classic synchronous components are not yet available here.
+    // We need to wait for the root instance to be set and patch it.
+    Object.defineProperty(app, '_instance', {
+      get() {
+        return rootInstance
+      },
+      set(newInstance) {
+        if (newInstance === app._instance) return
+        if (newInstance?.parent !== null) return
+
+        patchVueRenderer(newInstance, vNode)
+
+        rootInstance = newInstance
+      }
+    })
   }
 
   const show = (...args) => {

--- a/src/components/ModalsContainer.vue
+++ b/src/components/ModalsContainer.vue
@@ -73,6 +73,7 @@ import LoadingBars from './LoadingBars.vue'
 const PREFIX = 'dynamic_modal_'
 
 export default {
+  name: 'ModalsContainer',
   components: {
     LoadingBars
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,7 @@ export declare interface VueJSModalOptions {
   componentName?: string
   dialog?: boolean
   dialogComponentName?: string
+  devtools?: boolean
   dynamicDefaults?: object
 }
 


### PR DESCRIPTION
This PR adds [vuejs/devtools](https://github.com/vuejs/devtools) compatibility, so that the modals container and all its modals are shown in the component tree.

This is an **experimental feature** and opt-in:

```js
app.use(VueJsModal, { devtools: true })
```

## Screenshots

<img width="1407" height="463" alt="grafik" src="https://github.com/user-attachments/assets/119c6dc0-5b80-4a6c-a64a-af72107715ef" />
<img width="1407" height="650" alt="grafik" src="https://github.com/user-attachments/assets/417bfac0-2dc4-470c-b912-347feb7acb6c" />
