### PR TITLE
Fix DevTools Edge Case (Webpack Chunk Components)

### DIFF
--- a/src/PluginCore.js
+++ b/src/PluginCore.js
@@ -67,6 +67,7 @@ const PluginCore = (app, options = {}) => {
     if (!treeNode) return
 
     if (treeNode.component) {
+      patchVueRenderer(treeNode.component, vNode)
       walkTreeAndPush(treeNode.component.subTree, vNode)
     } else if (treeNode.children?.length) {
       treeNode.children.push(vNode)


### PR DESCRIPTION
When the Vue app root is an async component (defined via `defineAsyncComponent` / Webpack lazy chunks), the modal container vNode was injected into the live subtree via `walkTreeAndPush` but the component's `render()` function was never patched. On the next re-render, Vue's `componentUpdateFn` would diff the previous tree (which contained the modal container vNode) against the freshly rendered tree (which did not), causing:


```md
can't access property "shapeFlag", c2 is undefined

traverseStaticChildren@https://127.0.0.1:8081/build/js/main.js:24998:11
patchElement@https://127.0.0.1:8081/build/js/main.js:23935:31
processElement@https://127.0.0.1:8081/build/js/main.js:23784:19
patch@https://127.0.0.1:8081/build/js/main.js:23639:25
componentUpdateFn@https://127.0.0.1:8081/build/js/main.js:24348:14
run@https://127.0.0.1:8081/build/js/main.js:17076:19
runIfDirty@https://127.0.0.1:8081/build/js/main.js:17114:12
callWithErrorHandling@https://127.0.0.1:8081/build/js/main.js:19109:33
flushJobs@https://127.0.0.1:8081/build/js/main.js:19314:30
```

This was reliably triggered by opening a modal before the async chunk had fully settled, as that's when a re-render was most likely to race against the injected vNode.

**Fix:** `walkTreeAndPush` now calls `patchVueRenderer` on every component instance it encounters during the walk, not just the leaf. This ensures the modal container vNode is reproduced on every subsequent render regardless of where in the async component tree the real render function lives.


> [!NOTE]
> Affected chunks were defined like this:
> ```js
> const DashboardApp = defineAsyncComponent(
>     () => import(/* webpackChunkName: "chunk-app-dashboard" */ "./DashboardApp.vue")
> );
> ```
